### PR TITLE
fix: Update NoteList text size and empty folder message

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -6,14 +6,14 @@
 	overflow-x: hidden;
 	overflow-y: scroll;
 
-	> .notes {
+	>.notes {
 		display: flex;
 		overflow-x: hidden;
 	}
 
-	> .emptylist {
+	>.emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
+		font-size: x-large;
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);
@@ -21,7 +21,7 @@
 }
 
 .note-list-item {
- 	display: flex;
+	display: flex;
 }
 
 .note-list-item-wrapper {
@@ -29,7 +29,7 @@
 	position: relative;
 	box-sizing: border-box;
 
-	> .dragcursor {
+	>.dragcursor {
 		background-color: var(--joplin-color);
 		position: absolute;
 		z-index: 1000;

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -4,7 +4,7 @@ import Setting from '../../../models/Setting';
 import { FolderEntity } from '../../../services/database/types';
 import { getTrashFolderId, itemIsInTrash } from '../../../services/trash';
 
-const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string|null) => {
+const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string | null) => {
 	if (selectedFolderId === getTrashFolderId()) {
 		return _('There are no notes in the trash folder.');
 	} else if (selectedFolderId && itemIsInTrash(Folder.byId(folders, selectedFolderId))) {
@@ -12,7 +12,7 @@ const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string
 	}
 
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes in here. Create one by clicking on "New note".');
+		return _('No notes are present in the notebook. Create one by clicking on "New note".');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}


### PR DESCRIPTION

Desktop: Resolves #1  Update NoteList text size and empty folder message

![image](https://github.com/priyasirohi09/joplin/assets/101013814/38243291-ff46-44e3-a359-5055d9d41731)

changes NoteList empty text size to x-large and changes the text for empty folder.