### PR TITLE
Enhance placeholder text for empty notebooks

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	> .emptylist {
-		padding: 10px;
+		padding: 20px;
 		font-size: var(--joplin-font-size);
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);


### PR DESCRIPTION
Enhanced placeholder text for empty notebooks by increasing the padding for respective block