### PR TITLE
Added Icons to "New note" and "New to-do" Buttons

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -12,8 +12,8 @@
 	}
 
 	> .emptylist {
-		padding: 10px;
-		font-size: var(--joplin-font-size);
+		padding: 14px;
+		font-size: x-large;
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,15 +125,15 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
 	const todoIcon = useMemo(() => {
 		if (breakpoint === dynamicBreakpoints.Sm) {
-			return 'far fa-check-square';
+			return 'fas fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -12,7 +12,7 @@ const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string
 	}
 
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes in here. Create one by clicking on "New note".');
+		return _('Fresh start! Click "New note" to create something amazing 🚀');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

Added Icons to "New note" and "New to-do" Buttons
![image](https://github.com/priyasirohi09/joplin/assets/145591715/6cc3d5c6-af3b-4c1c-9d3a-b9a01eacaff0)
![image](https://github.com/priyasirohi09/joplin/assets/145591715/1303b8a4-efa6-40f0-9a70-563a624a6556)

changed plus icons to pencil icons by font awesome 