### PR TITLE
Enhance placeholder text for empty notebooks solve for #1

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,9 +13,9 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
+		font-size: 15px;
 		color: var(--joplin-color);
-		background-color: var(--joplin-background-color);
+		background-color: #e0e4e7;
 		font-family: var(--joplin-font-family);
 	}
 }


### PR DESCRIPTION
Enhance placeholder text for empty notebooks solve for #1

Increased font size and change background color.
![image](https://github.com/priyasirohi09/joplin/assets/95687419/81b29810-ba8a-40d1-b3aa-382dae0d4c3d)
