### PR TITLE
Add Icons to "New note" and "New to-do" Buttons

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,9 +13,9 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
+		font-size: 15px;
 		color: var(--joplin-color);
-		background-color: var(--joplin-background-color);
+		background-color: #e0e4e7;
 		font-family: var(--joplin-font-family);
 	}
 }

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
Added the pencil icons to the buttons .
commit [Add Icons to New note and New to-do Buttons](https://github.com/priyasirohi09/joplin/pull/71/commits/9722b58c4c5bc6310721846a88256cddd264c1a7) (fixes #2).
also commit [Enhance placeholder text for empty notebooks](https://github.com/priyasirohi09/joplin/pull/71/commits/61957c03225314938bb4566f03ab26199f76610f) (fixes #1).

![Screenshot from 2024-06-28 16-03-46](https://github.com/priyasirohi09/joplin/assets/95687419/6640bc35-94d0-4db6-8d34-61f3b97e5b42)
