### PR TITLE
Display seconds in timestamp

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	> .emptylist {
-		padding: 10px;
+		padding: 20px;
 		font-size: var(--joplin-font-size);
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
The current timestamp format displayed in the top bar includes the date and time (hours and minutes) but excludes seconds. Including seconds in the timestamp would enhance the precision of the displayed time, which can be particularly useful for users who require exact timing information for their activities.

