### PR TITLE
Added Pencil Icons to "New note" and "New to-do" Buttons

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
### Enhancement: Added Pencil Icons to Buttons

This update replaces the plus icons with pencil icons on buttons to help users quickly identify their purpose and enhance the overall user experience.

**Changes:**
- **Icon Update:**
 Replaced the plus icons with pencil icons from the Font Awesome library on the relevant buttons.

**Benefits:**

- **Improved Usability:** 
Users can more easily identify the purpose of each button at a glance.
- **Consistent Design:** 
The pencil icon better represents the action of editing, making the interface more intuitive.

**Screenshots:.**
![Icons_Issue2](https://github.com/priyasirohi09/joplin/assets/140935956/e67beb79-fc60-4f99-990d-acac46eae5af)


**Related Issue:**
Issue #2 : Add Icons to "New note" and "New to-do" Buttons
