### PR TITLE
Enhanced placeholder text for empty notebooks

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,8 +13,8 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
-		color: var(--joplin-color);
+		font-size: 19px;
+		color: darkred;
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);
 	}

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -12,7 +12,7 @@ const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string
 	}
 
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes in here. Create one by clicking on "New note".');
+		return _('No notes in this notebook. Click \'New note\' to start adding your notes.');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}


### PR DESCRIPTION
### **Enhancement: Improved Placeholder Text for Empty Notebooks**
This update enhances the placeholder text displayed when a notebook is empty to make it more noticeable and user-friendly.

**Changes:**

**1. Font Size Increase:**
The font size of the placeholder text has been increased for better visibility.

**2. Color Change:**
 The text color has been changed to dark red to make it stand out more.

**3.  Updated Message:**
  The message now reads: "No notes in this notebook. Click 'New note' to start adding your notes."

**Benefits:**

**1. Better Visibility:** 
The changes ensure users can easily see the placeholder text.

**2. Clear Call to Action:** 
The updated message guides users on how to start adding notes.

**Screenshots:**
**![Placeholder_Issue1](https://github.com/priyasirohi09/joplin/assets/140935956/afa7cf81-7639-407b-bf62-7853543f15b3)**

**Issue #1 : Enhance placeholder text for empty notebooks**