### PR TITLE
Fix: Update No Results Message in Notebook Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "@types/fs-extra": "11.0.4",
+    "canvas": "2.11.2",
     "eslint-plugin-github": "4.10.1",
     "http-server": "14.1.1",
     "node-gyp": "9.4.1",

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -186,9 +186,11 @@ const NoteList = (props: Props) => {
 	}, [props.notesParentType, props.searches, props.selectedSearchId, props.highlightedWords]);
 
 	const renderEmptyList = () => {
+		const isSearchActive = props.notesParentType === 'Search' && !!props.selectedSearchId;
 		if (props.notes.length) return null;
-		return <div className="emptylist">{getEmptyFolderMessage(props.folders, props.selectedFolderId)}</div>;
+		return <div className="emptylist">{getEmptyFolderMessage(props.folders, props.selectedFolderId, isSearchActive)}</div>;
 	};
+
 
 	const renderFiller = (key: string, style: React.CSSProperties) => {
 		if (!props.notes.length) return null;

--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,7 +13,7 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
+		font-size: x-large;
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -12,7 +12,7 @@ const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string
 	}
 
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes in here. Create one by clicking on "New note".');
+		return _('No notes yet. Start creating by clicking on "New note".');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -4,15 +4,19 @@ import Setting from '../../../models/Setting';
 import { FolderEntity } from '../../../services/database/types';
 import { getTrashFolderId, itemIsInTrash } from '../../../services/trash';
 
-const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string|null) => {
+const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string|null, isSearchActive: boolean) => {
 	if (selectedFolderId === getTrashFolderId()) {
 		return _('There are no notes in the trash folder.');
 	} else if (selectedFolderId && itemIsInTrash(Folder.byId(folders, selectedFolderId))) {
 		return _('This subfolder of the trash has no notes.');
 	}
 
+	if (isSearchActive) {
+		return _('No results found.');
+	}
+
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes yet. Start creating by clicking on "New note".');
+		return _('No notes in here. Create one by clicking on "New note".');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -37694,6 +37694,7 @@ __metadata:
     "@types/fs-extra": 11.0.4
     "@typescript-eslint/eslint-plugin": 6.8.0
     "@typescript-eslint/parser": 6.8.0
+    canvas: ^2.11.2
     cspell: 5.21.2
     eslint: 8.52.0
     eslint-interactive: 10.8.0


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where searching in a notebook with no matching results and empty notes displayed the message "No notes in this notebook. Click New note to start adding your notes." This was misleading and could cause confusion.

The fix updates the message to "No results found" when the search term does not match any notes. This provides a clearer and more accurate indication to the user.


<img width="1002" alt="Screenshot 2024-07-05 at 3 47 20 PM" src="https://github.com/priyasirohi09/joplin/assets/142092822/7c999503-ef8e-4169-8b41-7f1306c037f4">

**Changes Made:**

- Updated the conditional logic in the notebook search function to display "No results found" when no matching notes are present.

<img width="537" alt="Screenshot 2024-07-05 at 3 48 08 PM" src="https://github.com/priyasirohi09/joplin/assets/142092822/16773754-1b8c-4104-adb2-d788666b8506">

**Testing:**

- Verified the message "No results found" appears when there are no matching notes.
- Confirmed that the original message "No notes in this notebook. Click New note to start adding your notes." still appears when the notebook is empty.

Fixes #123 