### PR TITLE
Enhanced placeholder text for empty notes

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,8 +13,8 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
-		color: var(--joplin-color);
+		font-size: x-large;
+		color: blue;
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);
 	}


### PR DESCRIPTION

<img width="1680" alt="Screenshot 2024-07-05 at 11 54 16 PM" src="https://github.com/priyasirohi09/joplin/assets/155665460/89ed3adf-6a05-4916-883a-643789c90285">
Description:
Enhanced the placeholder text style for empty notes by increasing the font size and changing the color from black to blue. These changes improve the visibility and aesthetics of the placeholder text, making it more noticeable and user-friendly.

Changes:

Increased the font size of the placeholder text.
Changed the color of the placeholder text from black to blue.
Files Modified:

packages/app-desktop/gui/NoteList/style.scss
Reason:
To improve the user experience by making the placeholder text more visible and visually appealing.