### PR TITLE
Ayush307 k add pencil icon

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -1,4 +1,4 @@
-import { AppState } from '../../app.reducer';
+			return 'fas fa-pencil-alt';import { AppState } from '../../app.reducer';
 import * as React from 'react';
 import { useEffect, useRef, useMemo } from 'react';
 import SearchBar from '../SearchBar/SearchBar';
@@ -125,7 +125,8 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
+			
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -133,8 +133,8 @@ function NoteListControls(props: Props) {
 	const todoIcon = useMemo(() => {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
-		} else {
-			return 'fas fa-plus';
+		} else {			
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
Description:
Updated NoteListControls.tsx to utilize the 'pencil-alt' icon for note and todo actions based on the breakpoint and dynamicBreakpoints conditions. This change enhances the visual representation of note and todo functionalities, ensuring consistency and clarity across different screen sizes.

Changes Made:

Modified NoteListControls.tsx to conditionally render the 'pencil-alt' icon for note and todo actions when the breakpoint matches dynamicBreakpoints.Sm.
Ensured fallback to default icons ('fas fa-plus' for notes and 'far fa-check-square' for todos) when the breakpoint condition is not met.
Reason for Change:
To improve user interface consistency and usability by using a more appropriate icon ('pencil-alt') for note and todo actions on smaller screens, enhancing overall user experience.

<img width="1668" alt="Screenshot 2024-07-05 at 11 58 36 PM" src="https://github.com/priyasirohi09/joplin/assets/155665460/9319dc2b-1783-4e16-99ca-de574d5e6335">
