### PR TITLE
Changed Icon from plus to pencil

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fa fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fa fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
# Fixed Issue #2 
### Added the pencil icons to the new-note and new todo buttons instead of the plus

Here is the updated look

![image](https://github.com/priyasirohi09/joplin/assets/76900049/608eda70-8f4a-41a7-a32c-0f73bc819d23)
