### PR TITLE
Added icons for tags

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,8 +13,10 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
-		color: var(--joplin-color);
+		// font-size: var(--joplin-font-size);
+		// color: var(--joplin-color);
+		font-size: larger;
+		color:rgb(99, 99, 14);
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);
 	}

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
@@ -49,7 +49,7 @@ const TagItem = (props: Props) => {
 				onContextMenu={props.onContextMenu}
 				onClick={onClickHandler}
 			>
-				<StyledSpanFix className="tag-label">{Tag.displayTitle(tag)}</StyledSpanFix>
+				<StyledSpanFix className="tag-label"><i className="sc-hmdomO jeUOIH icon-tags"></i>{Tag.displayTitle(tag)}</StyledSpanFix>
 				{noteCount}
 			</StyledListItemAnchor>
 		</StyledListItem>


### PR DESCRIPTION
**Operating system**
Linux

**Joplin version**
2.14.22

**Desktop version info**

_How to reproduce_
-   create a notebook
-   create a note in it
-   right click and select Tags
-   add a tag
-   search from TAGS

**Previous behaviour**
It just lists the names of all tags as of now.
![Screenshot from 2024-07-08 12-11-06](https://github.com/priyasirohi09/joplin/assets/144247829/97e910d8-1abb-4586-8c8c-99c04c995d35)



**Current behaviour**
Its better to have an icon for each tag so that its easy for users to find notes filtered by tags.
![Screenshot from 2024-07-08 12-11-35](https://github.com/priyasirohi09/joplin/assets/144247829/49d407d5-b0fc-4d71-b013-5ce683b8fee3)
