### PR TITLE
Enhance timestamp to support seconds

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -4,7 +4,7 @@ import CommandService from '@joplin/lib/services/CommandService';
 import { ChangeEvent, useCallback } from 'react';
 import NoteToolbar from '../../NoteToolbar/NoteToolbar';
 import { buildStyle } from '@joplin/lib/theme';
-import time from '@joplin/lib/time';
+// import time from '@joplin/lib/time';
 import styled from 'styled-components';
 
 const StyledRoot = styled.div`
@@ -94,7 +94,12 @@ export default function NoteTitleBar(props: Props) {
 	}, []);
 
 	function renderTitleBarDate() {
-		return <span className="updated-time-label" style={styles.titleDate}>{time.formatMsToLocal(props.noteUserUpdatedTime)}</span>;
+		const date = new Date(props.noteUserUpdatedTime);
+		const formattedDate = date.toLocaleString('default', {
+			year: 'numeric', month: 'long', day: 'numeric',
+			hour: '2-digit', minute: '2-digit', second: '2-digit',
+		});
+		return <span className="updated-time-label" style={styles.titleDate}>{formattedDate}</span>;
 	}
 
 	function renderNoteToolbar() {


### PR DESCRIPTION
Title: Enhance renderTitleBarDate to Display Full Timestamp

Description:

This PR updates the renderTitleBarDate function within the [NoteTitleBar.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) file to display a more detailed timestamp, including the year, month, day, hour, minute, and second. Previously, the function utilized a custom time formatting method from the @joplin/lib/time module, which only showed a less detailed date format. The goal of this change is to provide users with precise information about when a note was last updated, enhancing the usability and information clarity of the Joplin desktop application.
![Screenshot from 2024-07-09 23-40-53](https://github.com/priyasirohi09/joplin/assets/141946130/13b6f885-436d-41e6-b917-4e08883752fb)


Changes made:

Removed the dependency on @joplin/lib/time for formatting the updated time in renderTitleBarDate.
Implemented JavaScript's native Date object and its toLocaleString method to format the props.noteUserUpdatedTime timestamp. This method allows for a more flexible and detailed representation of the date and time.
The formatted timestamp now includes the year, month, day, hour, minute, and second, providing a complete view of the last update time.
This update aims to improve the user experience by offering a more detailed and informative timestamp, making it easier for users to track their note modifications down to the exact second.