### PR TITLE
Added Icons near Tags

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -75,7 +75,7 @@ const useSidebarListData = (props: Props): ListItem[] => {
 		const tagsHeader: HeaderListItem = {
 			kind: ListItemType.Header,
 			label: _('Tags'),
-			iconName: 'icon-tags',
+			iconName: props.tagHeaderIsExpanded ? 'fas fa-caret-down' : 'fas fa-caret-right',
 			id: HeaderId.TagHeader,
 			key: HeaderId.TagHeader,
 			onClick: onHeaderClick,


### PR DESCRIPTION
# Enhancement: Added Toggle Tag Icons
This update changes the tag icon in the sidebar to reflect its expanded or collapsed state, improving the visual feedback for users.

## Changes:

**Icon Update:**
Tag icon now toggles between icon-tags-open and icon-tags-closed based on the expanded or collapsed state.

## Benefits:

- **Improved Usability:**
Users can easily see whether the tag section is expanded or collapsed at a glance.
- **Consistent Design:**
The icon change enhances the visual consistency and intuitiveness of the interface.

## Screenshots:

![Screenshot from 2024-07-10 15-01-25](https://github.com/priyasirohi09/joplin/assets/140935956/1557c467-9dd2-4142-bd5d-2b2cd549ec4b)  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![Screenshot from 2024-07-10 15-01-43](https://github.com/priyasirohi09/joplin/assets/140935956/7703a98e-cdce-4d67-9ec1-3cf1f6d9b3c3)


## Related Issue:
Issue #67: Add an Icon beside Tags to list all the tags present