### PR TITLE
issue1 resolved

### DIFF
--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -12,7 +12,7 @@ const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string
 	}
 
 	if (Setting.value('appType') === 'desktop') {
-		return _('No notes in here. Create one by clicking on "New note".');
+		return _('No notes available. Create one by clicking on "New note');
 	} else {
 		return _('There are currently no notes. Create one by clicking on the (+) button.');
 	}


### PR DESCRIPTION
#1
The current empty state message in the notes section reads: "No notes in here. Create one by clicking on 'New note'." This message can be improved for clarity and conciseness.

Proposed Change:
Rephrase the message to: "No notes available. Create one by clicking on 'New note'."