### PR TITLE
Changed icon of buttons to pencil

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt'; // changed icon to pencil
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt'; // changed icon to pencil
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
Changed icon of both buttons to `pencil`, this better conveys their purpose as it is to take notes.
This fixes #2.