### PR TITLE
Issue1 and Issue2 Resolved

### DIFF
--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -13,7 +13,7 @@
 
 	> .emptylist {
 		padding: 10px;
-		font-size: var(--joplin-font-size);
+		font-size: 20px;
 		color: var(--joplin-color);
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -125,7 +125,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
-			return 'fas fa-plus';
+			return 'fas fa-pencil-alt';
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 


### PR DESCRIPTION
Title: Enhance Placeholder Text for Empty Notebooks, Add Icons to "New Note" and "New To-Do" Buttons

Description:
This pull request addresses two issues:

Issue https://github.com/priyasirohi09/joplin/issues/1 - Enhance Placeholder Text for Empty Notebooks:

Updated the placeholder text in empty notebooks to provide clearer and more helpful instructions for users. The enhanced text guides users on how to get started with creating notes and to-dos.
Issue https://github.com/priyasirohi09/joplin/issues/2 - Add Icons to "New Note" and "New To-Do" Buttons:

Added appropriate icons to the "New Note" and "New To-Do" buttons to enhance visual guidance and improve user experience. The icons make the buttons more intuitive and accessible.



Images:

![Screenshot 2024-08-15 173455](https://github.com/user-attachments/assets/ae316ace-648b-400c-b121-828161f99729)

![Screenshot 2024-08-15 173529](https://github.com/user-attachments/assets/d33df03e-f3ab-4382-af6e-6c113e945348)
