### PR TITLE
Fix Error When Canceling Bulk PDF Export Due to Incorrect Handling of Return Type from `bridge().showOpenDialog()`

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/exportPdf.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/exportPdf.ts
@@ -3,7 +3,7 @@ import shim from '@joplin/lib/shim';
 import InteropServiceHelper from '../../../InteropServiceHelper';
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
-const bridge = require('@electron/remote').require('./bridge').default;
+import bridge from '../../../services/bridge';
 
 export const declaration: CommandDeclaration = {
 	name: 'exportPdf',
@@ -29,6 +29,14 @@ export const runtime = (comp: any): CommandRuntime => {
 					path = await bridge().showOpenDialog({
 						properties: ['openDirectory', 'createDirectory'],
 					});
+				}
+
+				if (Array.isArray(path)) {
+					if (path.length > 1) {
+						throw new Error('Only one output directory can be selected');
+					}
+
+					path = path[0];
 				}
 
 				if (!path) return;


### PR DESCRIPTION
### Description
This pull request addresses issue #280, which reports an error that occurs when canceling a bulk PDF export. The error arises because the code incorrectly assumes that `bridge().showOpenDialog()` always returns a string. In cases where no output paths are selected, the function returns an empty array (`[]`), leading to an error when the cancellation is processed.

#### Changes Implemented:
- Updated the code to properly handle the return type of `bridge().showOpenDialog()`, allowing for both strings and arrays of strings.
- Added a check to account for the possibility of receiving an empty array when no output paths are selected.
- Ensured that canceling the export operation does not trigger an error dialog.

#### Testing Plan:
1. Select two notes in the application.
2. Click "Export" > "PDF."
3. Click "Cancel."
4. Verify that no error dialog appears.
5. Select the same two notes again.
6. Click "Export," then "PDF."
7. Select an empty output directory.
8. Click "Open."
9. Verify that the directory contains the exported PDF files without any errors.

This fix has been successfully tested on Ubuntu 24.04.